### PR TITLE
Re-implement equals semantics for AST nodes

### DIFF
--- a/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/ast/Nodes.kt
+++ b/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/ast/Nodes.kt
@@ -14,43 +14,43 @@ import kotlin.reflect.full.memberProperties
 abstract class BaseNode {
 
     override fun equals(other: Any?) =
-            if (other is BaseNode) {
-                this.equals(other, emptySet())
-            } else {
-                false
-            }
+        if (other is BaseNode) {
+            this.equals(other, emptySet())
+        } else {
+            false
+        }
 
     fun equals(other: BaseNode, ignoredFields: Set<String> = setOf("span")): Boolean =
-            if (this::class == other::class) {
-                publicMemberProperties(this::class, ignoredFields).all {
-                    val thisValue = it.getter.call(this)
-                    val otherValue = it.getter.call(other)
-                    if (thisValue is Collection<*> && otherValue is Collection<*>) {
-                        if (thisValue.size == otherValue.size) {
-                            thisValue.zip(otherValue).all { (a, b) -> scalarsEqual(a, b, ignoredFields) }
-                        } else {
-                            false
-                        }
+        if (this::class == other::class) {
+            publicMemberProperties(this::class, ignoredFields).all {
+                val thisValue = it.getter.call(this)
+                val otherValue = it.getter.call(other)
+                if (thisValue is Collection<*> && otherValue is Collection<*>) {
+                    if (thisValue.size == otherValue.size) {
+                        thisValue.zip(otherValue).all { (a, b) -> scalarsEqual(a, b, ignoredFields) }
                     } else {
-                        scalarsEqual(thisValue, otherValue, ignoredFields)
+                        false
                     }
+                } else {
+                    scalarsEqual(thisValue, otherValue, ignoredFields)
                 }
-            } else {
-                false
             }
+        } else {
+            false
+        }
 
     private companion object {
         private fun publicMemberProperties(clazz: KClass<*>, ignoredFields: Set<String>) =
-                clazz.memberProperties
-                        .filter { it.visibility == KVisibility.PUBLIC }
-                        .filterNot { ignoredFields.contains(it.name) }
+            clazz.memberProperties
+                .filter { it.visibility == KVisibility.PUBLIC }
+                .filterNot { ignoredFields.contains(it.name) }
 
         private fun scalarsEqual(left: Any?, right: Any?, ignoredFields: Set<String>) =
-                if (left is BaseNode && right is BaseNode) {
-                    left.equals(right, ignoredFields)
-                } else {
-                    left == right
-                }
+            if (left is BaseNode && right is BaseNode) {
+                left.equals(right, ignoredFields)
+            } else {
+                left == right
+            }
     }
 }
 
@@ -118,7 +118,8 @@ class NumberLiteral(value: String) : VariantKey, Literal(value)
 
 class MessageReference(var id: Identifier, var attribute: Identifier? = null) : Expression()
 
-class TermReference(var id: Identifier, var attribute: Identifier? = null, var arguments: CallArguments? = null) : Expression()
+class TermReference(var id: Identifier, var attribute: Identifier? = null, var arguments: CallArguments? = null) :
+    Expression()
 
 class VariableReference(var id: Identifier) : Expression()
 

--- a/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/ast/Nodes.kt
+++ b/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/ast/Nodes.kt
@@ -1,5 +1,6 @@
 package org.projectfluent.syntax.ast
 
+import kotlin.reflect.KClass
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.memberProperties
 
@@ -11,41 +12,46 @@ import kotlin.reflect.full.memberProperties
  *
  */
 abstract class BaseNode {
-    fun nodeEquals(other: BaseNode?, ignoredFields: Array<String> = arrayOf("span")): Boolean {
-        if (other == null) return false
-        if (this::class != other::class) return false
-        val otherMembers = hashMapOf<String, Any?>()
-        other::class.memberProperties.forEach {
-            if (it.visibility == KVisibility.PUBLIC && ! ignoredFields.contains(it.name)) {
-                otherMembers[it.name] = it.getter.call(other)
+
+    override fun equals(other: Any?) =
+            if (other is BaseNode) {
+                this.equals(other, emptySet())
+            } else {
+                false
             }
-        }
-        this::class.memberProperties.forEach {
-            if (it.name in otherMembers) {
-                val value = it.getter.call(this)
-                val otherValue = otherMembers[it.name]
-                if (value is Collection<*> && otherValue is Collection<*>) {
-                    if (value.size != otherValue.size) return false
-                    for ((left, right) in value.zip(otherValue)) {
-                        if (! scalarsEqual(left!!, right!!, ignoredFields)) return false
+
+    fun equals(other: BaseNode, ignoredFields: Set<String> = setOf("span")): Boolean =
+            if (this::class == other::class) {
+                publicMemberProperties(this::class, ignoredFields).all {
+                    val thisValue = it.getter.call(this)
+                    val otherValue = it.getter.call(other)
+                    if (thisValue is Collection<*> && otherValue is Collection<*>) {
+                        if (thisValue.size == otherValue.size) {
+                            thisValue.zip(otherValue).all { (a, b) -> scalarsEqual(a, b, ignoredFields) }
+                        } else {
+                            false
+                        }
+                    } else {
+                        scalarsEqual(thisValue, otherValue, ignoredFields)
                     }
-                } else if (! scalarsEqual(value, otherValue, ignoredFields)) {
-                    return false
                 }
+            } else {
+                false
             }
-        }
-        return true
-    }
 
-    override fun equals(other: Any?): Boolean {
-        if (other is BaseNode) return this.nodeEquals(other, arrayOf())
-        return false
-    }
-}
+    private companion object {
+        private fun publicMemberProperties(clazz: KClass<*>, ignoredFields: Set<String>) =
+                clazz.memberProperties
+                        .filter { it.visibility == KVisibility.PUBLIC }
+                        .filterNot { ignoredFields.contains(it.name) }
 
-private fun scalarsEqual(left: Any?, right: Any?, ignoredFields: Array<String>): Boolean {
-    if (left is BaseNode && right is BaseNode) return left.nodeEquals(right, ignoredFields = ignoredFields)
-    return left == right
+        private fun scalarsEqual(left: Any?, right: Any?, ignoredFields: Set<String>) =
+                if (left is BaseNode && right is BaseNode) {
+                    left.equals(right, ignoredFields)
+                } else {
+                    left == right
+                }
+    }
 }
 
 /**
@@ -76,12 +82,12 @@ abstract class TopLevel : SyntaxNode()
  */
 abstract class Entry : TopLevel()
 
-data class Message(var id: Identifier, var value: Pattern?) : Entry() {
+class Message(var id: Identifier, var value: Pattern?) : Entry() {
     var attributes: MutableList<Attribute> = mutableListOf()
     var comment: Comment? = null
 }
 
-data class Term(var id: Identifier, var value: Pattern) : Entry() {
+class Term(var id: Identifier, var value: Pattern) : Entry() {
     var attributes: MutableList<Attribute> = mutableListOf()
     var comment: Comment? = null
 }
@@ -96,11 +102,11 @@ class Pattern(vararg elements: PatternElement) : SyntaxNode() {
 
 abstract class PatternElement : SyntaxNode()
 
-data class TextElement(var value: String) : PatternElement()
+class TextElement(var value: String) : PatternElement()
 
 interface InsidePlaceable
 
-data class Placeable(var expression: InsidePlaceable) : InsidePlaceable, PatternElement()
+class Placeable(var expression: InsidePlaceable) : InsidePlaceable, PatternElement()
 
 abstract class Expression : CallArgument, InsidePlaceable, SyntaxNode()
 
@@ -110,15 +116,15 @@ class StringLiteral(value: String) : Literal(value)
 
 class NumberLiteral(value: String) : VariantKey, Literal(value)
 
-data class MessageReference(var id: Identifier, var attribute: Identifier? = null) : Expression()
+class MessageReference(var id: Identifier, var attribute: Identifier? = null) : Expression()
 
-data class TermReference(var id: Identifier, var attribute: Identifier? = null, var arguments: CallArguments? = null) : Expression()
+class TermReference(var id: Identifier, var attribute: Identifier? = null, var arguments: CallArguments? = null) : Expression()
 
-data class VariableReference(var id: Identifier) : Expression()
+class VariableReference(var id: Identifier) : Expression()
 
-data class FunctionReference(var id: Identifier, var arguments: CallArguments) : Expression()
+class FunctionReference(var id: Identifier, var arguments: CallArguments) : Expression()
 
-data class SelectExpression(var selector: Expression, var variants: MutableList<Variant>) : Expression()
+class SelectExpression(var selector: Expression, var variants: MutableList<Variant>) : Expression()
 
 interface CallArgument
 
@@ -127,15 +133,15 @@ class CallArguments : SyntaxNode() {
     val named: MutableList<NamedArgument> = mutableListOf()
 }
 
-data class Attribute(var id: Identifier, var value: Pattern) : SyntaxNode()
+class Attribute(var id: Identifier, var value: Pattern) : SyntaxNode()
 
 interface VariantKey
 
-data class Variant(var key: VariantKey, var value: Pattern, var default: Boolean) : SyntaxNode()
+class Variant(var key: VariantKey, var value: Pattern, var default: Boolean) : SyntaxNode()
 
-data class NamedArgument(var name: Identifier, var value: Literal) : CallArgument, SyntaxNode()
+class NamedArgument(var name: Identifier, var value: Literal) : CallArgument, SyntaxNode()
 
-data class Identifier(var name: String) : VariantKey, SyntaxNode()
+class Identifier(var name: String) : VariantKey, SyntaxNode()
 
 abstract class BaseComment(var content: String) : Entry()
 
@@ -145,7 +151,7 @@ class GroupComment(content: String) : BaseComment(content)
 
 class ResourceComment(content: String) : BaseComment(content)
 
-data class Junk(val content: String) : TopLevel() {
+class Junk(val content: String) : TopLevel() {
     val annotations: MutableList<Annotation> = mutableListOf()
     fun addAnnotation(annotation: Annotation) {
         this.annotations.add(annotation)
@@ -157,10 +163,10 @@ data class Junk(val content: String) : TopLevel() {
  *
  * Extension of the data model in other implementations.
  */
-data class Whitespace(val content: String) : TopLevel()
+class Whitespace(val content: String) : TopLevel()
 
-data class Span(var start: Int, var end: Int) : BaseNode()
+class Span(var start: Int, var end: Int) : BaseNode()
 
-data class Annotation(var code: String, var message: String) : SyntaxNode() {
+class Annotation(var code: String, var message: String) : SyntaxNode() {
     val arguments: MutableList<Any> = mutableListOf()
 }

--- a/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/ast/BaseNodeTest.kt
+++ b/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/ast/BaseNodeTest.kt
@@ -5,61 +5,64 @@ import org.junit.jupiter.api.Test
 import org.projectfluent.syntax.parser.FluentParser
 
 class BaseNodeTest {
-    val parser = FluentParser()
-    @Test fun test_equals() {
+    private val parser = FluentParser()
+
+    @Test
+    fun testEquals() {
         val m1 = Message(Identifier("test-id"), Pattern(TextElement("localized")))
-        assertTrue(m1.nodeEquals(m1))
         val m2 = Message(Identifier("test-id"), Pattern(TextElement("different")))
-        assertFalse(m1.nodeEquals(m2))
-        assertTrue(m1.nodeEquals(m2, arrayOf("span", "value")))
+
+        assertEquals(m1, m1)
         assertNotEquals(m1, m2)
         assertEquals(m1.id, m2.id)
-        assertFalse(m1.id.nodeEquals(m2.value))
-        assertFalse(m1.nodeEquals(null))
+        assertNotEquals(m1.value, m2.value)
         assertNotEquals(m1, null)
         assertNotEquals(null, m1)
     }
 
     @Test
-    fun variant_order() {
-        val thisRes = this.parser.parse(
-            """
-            |msg = { ${'$'}val ->
-            |  [few] things
-            |  [1] one
-            | *[other] default
-            |}
-        """.trimMargin()
-        )
-        val otherRes = this.parser.parse(
-            """
-            |msg = { ${'$'}val ->
-            |  [few] things
-            | *[other] default
-            |  [1] one
-            |}
-        """.trimMargin()
-        )
-        assertTrue(thisRes.body[0].nodeEquals(otherRes.body[0], ignoredFields = arrayOf("span", "variants")))
-        assertFalse(thisRes.body[0].nodeEquals(otherRes.body[0]))
+    fun testEqualsWithIgnoredFields() {
+        val m1 = Message(Identifier("test-id"), Pattern(TextElement("localized")))
+        val m2 = Message(Identifier("test-id"), Pattern(TextElement("different")))
+
+        assertTrue(m1.equals(m2, setOf("span", "value")))
     }
+
     @Test
-    fun attribute_order() {
-        val thisRes = this.parser.parse(
-            """
+    fun variantOrderIsImportantForEquals() {
+        val resource1 = this.parser.parse("""
+            |msg = { ${'$'}val ->
+            |  [few] things
+            |  [1] one
+            | *[other] default
+            |}
+        """.trimMargin())
+        val resource2 = this.parser.parse("""
+            |msg = { ${'$'}val ->
+            |  [few] things
+            | *[other] default
+            |  [1] one
+            |}
+        """.trimMargin())
+
+        assertTrue(resource1.body[0].equals(resource2.body[0], ignoredFields = setOf("span", "variants")))
+        assertNotEquals(resource1.body[0], resource2.body[0])
+    }
+
+    @Test
+    fun attributeOrderIsImportantForEquals() {
+        val resource1 = this.parser.parse("""
             |msg =
             |  .attr1 = one
             |  .attr2 = two
-        """.trimMargin()
-        )
-        val otherRes = this.parser.parse(
-            """
+        """.trimMargin())
+        val resource2 = this.parser.parse("""
             |msg =
             |  .attr2 = two
             |  .attr1 = one
-        """.trimMargin()
-        )
-        assertTrue(thisRes.body[0].nodeEquals(otherRes.body[0], ignoredFields = arrayOf("span", "attributes")))
-        assertFalse(thisRes.body[0].nodeEquals(otherRes.body[0]))
+        """.trimMargin())
+
+        assertTrue(resource1.body[0].equals(resource2.body[0], ignoredFields = setOf("span", "attributes")))
+        assertNotEquals(resource1.body[0], resource2.body[0])
     }
 }

--- a/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/ast/BaseNodeTest.kt
+++ b/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/ast/BaseNodeTest.kt
@@ -30,20 +30,24 @@ class BaseNodeTest {
 
     @Test
     fun variantOrderIsImportantForEquals() {
-        val resource1 = this.parser.parse("""
+        val resource1 = this.parser.parse(
+            """
             |msg = { ${'$'}val ->
             |  [few] things
             |  [1] one
             | *[other] default
             |}
-        """.trimMargin())
-        val resource2 = this.parser.parse("""
+        """.trimMargin()
+        )
+        val resource2 = this.parser.parse(
+            """
             |msg = { ${'$'}val ->
             |  [few] things
             | *[other] default
             |  [1] one
             |}
-        """.trimMargin())
+        """.trimMargin()
+        )
 
         assertTrue(resource1.body[0].equals(resource2.body[0], ignoredFields = setOf("span", "variants")))
         assertNotEquals(resource1.body[0], resource2.body[0])
@@ -51,16 +55,20 @@ class BaseNodeTest {
 
     @Test
     fun attributeOrderIsImportantForEquals() {
-        val resource1 = this.parser.parse("""
+        val resource1 = this.parser.parse(
+            """
             |msg =
             |  .attr1 = one
             |  .attr2 = two
-        """.trimMargin())
-        val resource2 = this.parser.parse("""
+        """.trimMargin()
+        )
+        val resource2 = this.parser.parse(
+            """
             |msg =
             |  .attr2 = two
             |  .attr1 = one
-        """.trimMargin())
+        """.trimMargin()
+        )
 
         assertTrue(resource1.body[0].equals(resource2.body[0], ignoredFields = setOf("span", "attributes")))
         assertNotEquals(resource1.body[0], resource2.body[0])


### PR DESCRIPTION
- replace custom nodeEquals method by overloading equals
- implement equals with ignoredFields using Kotlin collection operations
- reduce reflection calls
- avoid nullability in equals
- fix equals semantics for BaseNode children (data classes have implicit equals with other than expected behaviour)

split from #28 